### PR TITLE
feat: manifest + bin fallback, executable fixes, release workflow (0.3.2)

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -1,0 +1,77 @@
+name: Publish (npm) on tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Validate & Publish
+    runs-on: ubuntu-latest
+    if: github.repository == 'FRAQTIV/gitrules-mcp-server'
+    permissions:
+      contents: write  # needed for release notes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME}"        # e.g. v0.3.2
+          VERSION="${TAG#v}"             # strip leading v
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Tag: $TAG  -> Version: $VERSION  package.json: $PKG_VERSION"
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($VERSION) does not match package.json ($PKG_VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo '::error::NPM_TOKEN secret missing'; exit 1; fi
+          npm publish --access public
+
+      - name: Generate release notes section
+        id: notes
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          awk -v ver="${VERSION}" 'BEGIN{in=0} /^## \["ver"\]/ {in=1; next} /^## \[/ {if (in) exit} {if (in) print}' CHANGELOG.md > RELEASE_NOTES.md || true
+          if [ ! -s RELEASE_NOTES.md ]; then echo "No changelog section found" > RELEASE_NOTES.md; fi
+          echo '--- RELEASE NOTES ---'
+          cat RELEASE_NOTES.md
+          echo '---------------------'
+          NOTES_ESCAPED=$(sed "s/'/'"'"'"'/g" RELEASE_NOTES.md | sed ':a;N;$!ba;s/\n/%0A/g')
+          echo "notes=$NOTES_ESCAPED" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.notes.outputs.notes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -59,7 +59,7 @@ jobs:
         id: notes
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          awk -v ver="${VERSION}" 'BEGIN{in=0} /^## \["ver"\]/ {in=1; next} /^## \[/ {if (in) exit} {if (in) print}' CHANGELOG.md > RELEASE_NOTES.md || true
+          awk -v ver="${VERSION}" 'BEGIN{in=0} $0 ~ ("^## \\[" ver "\\]") {in=1; next} /^## \[/ {if (in) exit} {if (in) print}' CHANGELOG.md > RELEASE_NOTES.md || true
           if [ ! -s RELEASE_NOTES.md ]; then echo "No changelog section found" > RELEASE_NOTES.md; fi
           echo '--- RELEASE NOTES ---'
           cat RELEASE_NOTES.md

--- a/README.md
+++ b/README.md
@@ -250,6 +250,43 @@ npm link   # exposes global symlinks
 
 ### MCP Client Configuration Examples
 
+## Release Process
+
+Automated publish occurs when a git tag matching pattern `v*` is pushed to the
+origin repository (workflow: `publish-on-tag.yml`). Steps to cut a release:
+
+1. Ensure main (or develop) contains the desired commits.
+1. Update `package.json` version & add a CHANGELOG section `## [x.y.z] - YYYY-MM-DD`.
+1. Commit & merge via PR.
+1. Create and push tag:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+1. Workflow validates version match, runs tests, publishes to npm, then creates
+	a GitHub Release with the matched changelog section.
+
+Requirements:
+
+- Secret `NPM_TOKEN` (publish rights for the @fraqtiv scope) in repo settings.
+- Tag version must equal `package.json` version (without the leading `v`).
+
+Dry Run (local validation):
+
+```bash
+TAG=v0.0.0-test
+VERSION=${TAG#v}
+PKG=$(node -p "require('./package.json').version")
+echo $TAG $VERSION $PKG
+npm pack --dry-run
+```
+
+If publish fails (e.g., 403), verify the token scope and that the version has
+not already been published (npm prohibits overwriting existing versions).
+
+
 Claude Desktop / VS Code (settings fragment):
 
 ```jsonc


### PR DESCRIPTION
Adds mcp-manifest.json (schema_version, id, command/args).
Bin wrappers with dev fallback (src if dist missing).
Executable permission enforcement script (prepare).
GitHub Action: publish on v* tag (build/test/version check/publish/release).
README: release process & troubleshooting.
New tests: manifest shape, JSON-RPC, hooks, policy markdown.
Version bump: 0.3.2. Risk: low (additive, dev convenience; no breaking schema changes). Follow-up: finish README lint cleanup, add rule IDs to validation output.